### PR TITLE
feat: add LinkedIn profile photo to homepage avatar

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,6 @@
             width: 150px;
             height: 150px;
             border-radius: 50%;
-            background: var(--secondary);
             margin: 0 auto 2rem;
             display: flex;
             align-items: center;
@@ -168,6 +167,10 @@
             color: var(--primary);
             border: 5px solid rgba(255,255,255,0.2);
             box-shadow: 0 10px 40px rgba(0,0,0,0.3);
+            background-image: url('https://media.licdn.com/dms/image/v2/D4E03AQHxtsD-cbZahw/profile-displayphoto-shrink_400_400/profile-displayphoto-shrink_400_400/0/1671804217697?e=1776902400&v=beta&t=VIFVeHwqYVy5NYG84grptgBHmgJ__o94eZvVzop6hvA');
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
         }
 
         .hero h1 {
@@ -874,7 +877,7 @@
     <!-- Hero Section -->
     <header class="hero" id="home">
         <div class="hero-content">
-            <div class="hero-avatar">CELJ</div>
+            <div class="hero-avatar"></div>
             <h1>Carlos Eduardo de Lima Joaquim</h1>
             <p class="hero-subtitle">Data Engineer | Python Developer | Machine Learning Researcher</p>
             <p class="hero-location"><i class="fas fa-map-marker-alt"></i> Federal District, Brazil</p>


### PR DESCRIPTION
## Changes

- **Profile Photo**: Added LinkedIn profile photo to the hero section avatar
  - Replaced text-based 'CELJ' avatar with actual profile image
  - Maintained circular design with border and shadow effects
  - Photo loads from LinkedIn CDN URL

- **Responsive Design**: Avatar remains fully responsive across all device sizes

This enhances the personal branding of the homepage with a professional photo while keeping the existing elegant design.