### PR TITLE
feat: add all certifications and Portuguese language support

### DIFF
--- a/index-pt.html
+++ b/index-pt.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-BR">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Carlos Eduardo de Lima Joaquim - Data Engineer, Python Developer & Machine Learning Researcher at Ministry of Defense, Brazil">
-    <meta name="keywords" content="Data Engineer, Python Developer, Machine Learning, NLP, Carlos Eduardo de Lima Joaquim">
-    <title>Carlos Eduardo de Lima Joaquim | Data Engineer & Python Developer</title>
+    <meta name="description" content="Carlos Eduardo de Lima Joaquim - Engenheiro de Dados, Desenvolvedor Python & Pesquisador de Machine Learning no Ministério da Defesa, Brasil">
+    <meta name="keywords" content="Engenheiro de Dados, Desenvolvedor Python, Machine Learning, PLN, Carlos Eduardo de Lima Joaquim">
+    <title>Carlos Eduardo de Lima Joaquim | Engenheiro de Dados & Desenvolvedor Python</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
     <style>
@@ -907,32 +907,32 @@
     <nav id="navbar">
         <div class="nav-container">
             <a href="#" class="nav-logo">CE<span>LJ</span></a>
-            <button class="nav-toggle" aria-label="Toggle navigation">
+            <button class="nav-toggle" aria-label="Alternar navegação">
                 <i class="fas fa-bars"></i>
             </button>
             <ul class="nav-links">
-                <li><a href="#about">About</a></li>
-                <li><a href="#experience">Experience</a></li>
-                <li><a href="#education">Education</a></li>
-                <li><a href="#skills">Skills</a></li>
-                <li><a href="#certifications">Certifications</a></li>
-                <li><a href="#publications">Publications</a></li>
-                <li><a href="#contact">Contact</a></li>
+                <li><a href="#sobre">Sobre</a></li>
+                <li><a href="#experiencia">Experiência</a></li>
+                <li><a href="#formacao">Formação</a></li>
+                <li><a href="#habilidades">Habilidades</a></li>
+                <li><a href="#certificacoes">Certificações</a></li>
+                <li><a href="#publicacoes">Publicações</a></li>
+                <li><a href="#contato">Contato</a></li>
             </ul>
             <div class="lang-switcher">
-                <a href="index.html" class="lang-btn active">🇺🇸 EN</a>
-                <a href="index-pt.html" class="lang-btn">🇧🇷 PT</a>
+                <a href="index.html" class="lang-btn">🇺🇸 EN</a>
+                <a href="index-pt.html" class="lang-btn active">🇧🇷 PT</a>
             </div>
         </div>
     </nav>
 
     <!-- Hero Section -->
-    <header class="hero" id="home">
+    <header class="hero" id="inicio">
         <div class="hero-content">
             <div class="hero-avatar"></div>
             <h1>Carlos Eduardo de Lima Joaquim</h1>
-            <p class="hero-subtitle">AI Engineer | Data Engineer | Data Scientist | Machine Learning Researcher</p>
-            <p class="hero-location"><i class="fas fa-map-marker-alt"></i> Federal District, Brazil</p>
+            <p class="hero-subtitle">Engenheiro de IA | Engenheiro de Dados | Cientista de Dados | Pesquisador de Machine Learning</p>
+            <p class="hero-location"><i class="fas fa-map-marker-alt"></i> Distrito Federal, Brasil</p>
             <div class="hero-links">
                 <a href="https://www.linkedin.com/in/eduardodelima/" target="_blank" rel="noopener noreferrer">
                     <i class="fab fa-linkedin"></i> LinkedIn
@@ -951,50 +951,50 @@
     </header>
 
     <!-- About Section -->
-    <section class="about" id="about">
+    <section class="about" id="sobre">
         <div class="container">
             <div class="section-header fade-in">
-                <h2>About Me</h2>
+                <h2>Sobre Mim</h2>
                 <div class="section-divider"></div>
-                <p>Over 25 years of progressive experience in Brazil's defense and technology sectors</p>
+                <p>Mais de 25 anos de experiência progressiva nos setores de defesa e tecnologia do Brasil</p>
             </div>
             <div class="about-content">
                 <div class="about-text fade-in">
                     <p>
-                        I am a dedicated professional with a career spanning more than two decades in the Brazilian Army and Ministry of Defense. My journey has taken me from foundational roles in network administration and cybersecurity incident response to my current position as a Data Engineer and Python Developer.
+                        Sou um profissional dedicado com uma carreira que abrange mais de duas décadas no Exército Brasileiro e no Ministério da Defesa. Minha jornada me levou de funções fundamentais em administração de redes e resposta a incidentes de segurança cibernética até minha posição atual como Engenheiro de Dados e Desenvolvedor Python.
                     </p>
                     <p>
-                        Holding a Master's degree in Computer Science from the University of Brasília (UnB), with a focus on Natural Language Processing and machine learning applications for document classification, I combine deep technical expertise with practical military and defense domain knowledge.
+                        Com Mestrado em Ciência da Computação pela Universidade de Brasília (UnB), com foco em Processamento de Linguagem Natural e aplicações de machine learning para classificação de documentos, combino profunda expertise técnica com conhecimento prático do domínio militar e de defesa.
                     </p>
                     <p>
-                        My research interests include machine learning, NLP, sentiment analysis, and data-driven decision making. I am passionate about leveraging technology to solve complex problems and improve operational efficiency in large organizations.
+                        Meus interesses de pesquisa incluem machine learning, PLN, análise de sentimentos e tomada de decisão orientada por dados. Sou apaixonado por usar a tecnologia para resolver problemas complexos e melhorar a eficiência operacional em grandes organizações.
                     </p>
                 </div>
                 <div class="about-highlights fade-in">
-                    <h3>Key Highlights</h3>
+                    <h3>Destaques</h3>
                     <div class="highlight-item">
                         <i class="fas fa-award"></i>
-                        <span>25+ years in Brazilian Defense sector</span>
+                        <span>25+ anos no setor de Defesa Brasileiro</span>
                     </div>
                     <div class="highlight-item">
                         <i class="fas fa-graduation-cap"></i>
-                        <span>M.Sc. Computer Science – University of Brasília</span>
+                        <span>Mestrado em Ciência da Computação – UnB</span>
                     </div>
                     <div class="highlight-item">
                         <i class="fas fa-code"></i>
-                        <span>Data Engineering & Python Development</span>
+                        <span>Engenharia de Dados & Desenvolvimento Python</span>
                     </div>
                     <div class="highlight-item">
                         <i class="fas fa-brain"></i>
-                        <span>Machine Learning & NLP Research</span>
+                        <span>Pesquisa em Machine Learning & PLN</span>
                     </div>
                     <div class="highlight-item">
                         <i class="fas fa-shield-alt"></i>
-                        <span>Cybersecurity & Information Security</span>
+                        <span>Segurança Cibernética & da Informação</span>
                     </div>
                     <div class="highlight-item">
                         <i class="fas fa-file-alt"></i>
-                        <span>Published Researcher (LION, RISTI)</span>
+                        <span>Pesquisador Publicado (LION, RISTI)</span>
                     </div>
                 </div>
             </div>
@@ -1002,66 +1002,66 @@
     </section>
 
     <!-- Experience Section -->
-    <section class="experience" id="experience">
+    <section class="experience" id="experiencia">
         <div class="container">
             <div class="section-header fade-in">
-                <h2>Professional Experience</h2>
+                <h2>Experiência Profissional</h2>
                 <div class="section-divider"></div>
-                <p>A career of continuous growth within Brazil's Defense Institutions</p>
+                <p>Uma carreira de crescimento contínuo nas Instituições de Defesa do Brasil</p>
             </div>
             <div class="timeline">
                 <div class="timeline-item fade-in">
                     <div class="timeline-dot"></div>
                     <div class="timeline-content">
-                        <span class="timeline-date">2025 – Present</span>
-                        <h3>Data Engineer & Python Developer</h3>
-                        <span class="company">Ministry of Defense (Ministério da Defesa)</span>
-                        <p>Member of Project BIEG. Developing data pipelines, machine learning models, and data science solutions to support defense operations and decision-making processes.</p>
+                        <span class="timeline-date">2025 – Presente</span>
+                        <h3>Engenheiro de Dados & Desenvolvedor Python</h3>
+                        <span class="company">Ministério da Defesa</span>
+                        <p>Membro do Projeto BIEG. Desenvolvimento de pipelines de dados, modelos de machine learning e soluções de ciência de dados para apoiar operações e processos decisórios de defesa.</p>
                     </div>
                 </div>
                 <div class="timeline-item fade-in">
                     <div class="timeline-dot"></div>
                     <div class="timeline-content">
                         <span class="timeline-date">2021 – 2025</span>
-                        <h3>Systems Analyst & Java Developer</h3>
-                        <span class="company">Brazilian Army (Exército Brasileiro)</span>
-                        <p>Designed and developed enterprise systems, performed systems analysis, and contributed to software architecture for military administrative applications.</p>
+                        <h3>Analista de Sistemas & Desenvolvedor Java</h3>
+                        <span class="company">Exército Brasileiro</span>
+                        <p>Projetou e desenvolveu sistemas empresariais, realizou análise de sistemas e contribuiu para a arquitetura de software para aplicações administrativas militares.</p>
                     </div>
                 </div>
                 <div class="timeline-item fade-in">
                     <div class="timeline-dot"></div>
                     <div class="timeline-content">
                         <span class="timeline-date">2016 – 2021</span>
-                        <h3>Information Security Analyst & Senior DevOps Engineer</h3>
-                        <span class="company">Brazilian Army</span>
-                        <p>Led DevOps practices, managed CI/CD pipelines, and ensured information security compliance across military IT infrastructure.</p>
+                        <h3>Analista de Segurança da Informação & Engenheiro DevOps Sênior</h3>
+                        <span class="company">Exército Brasileiro</span>
+                        <p>Liderou práticas de DevOps, gerenciou pipelines de CI/CD e garantiu a conformidade de segurança da informação na infraestrutura de TI militar.</p>
                     </div>
                 </div>
                 <div class="timeline-item fade-in">
                     <div class="timeline-dot"></div>
                     <div class="timeline-content">
                         <span class="timeline-date">2011 – 2016</span>
-                        <h3>Information Security Analyst & Network Manager</h3>
-                        <span class="company">Brazilian Army</span>
-                        <p>Managed network infrastructure, implemented security policies, and oversaw the administration of military communication systems.</p>
+                        <h3>Analista de Segurança da Informação & Gerente de Redes</h3>
+                        <span class="company">Exército Brasileiro</span>
+                        <p>Gerenciou infraestrutura de rede, implementou políticas de segurança e supervisionou a administração de sistemas de comunicação militares.</p>
                     </div>
                 </div>
                 <div class="timeline-item fade-in">
                     <div class="timeline-dot"></div>
                     <div class="timeline-content">
                         <span class="timeline-date">2010 – 2011</span>
-                        <h3>Information Security Analyst & Development Analyst</h3>
-                        <span class="company">Brazilian Army</span>
-                        <p>Conducted security analysis, supported software development initiatives, and contributed to network administration tasks.</p>
+                        <h3>Analista de Segurança da Informação & Analista de Desenvolvimento</h3>
+                        <span class="company">Exército Brasileiro</span>
+                        <p>Realizou análise de segurança, apoiou iniciativas de desenvolvimento de software e contribuiu para tarefas de administração de rede.</p>
                     </div>
                 </div>
                 <div class="timeline-item fade-in">
                     <div class="timeline-dot"></div>
                     <div class="timeline-content">
                         <span class="timeline-date">2000 – 2010</span>
-                        <h3>Network Administrator & CSIRT Member</h3>
-                        <span class="company">Brazilian Army</span>
-                        <p>Started career as a Network Administrator and served as a member of the Computer Security Incident Response Team (CSIRT), building foundational expertise in cybersecurity.</p>
+                        <h3>Administrador de Redes & Membro do CSIRT</h3>
+                        <span class="company">Exército Brasileiro</span>
+                        <p>Iniciou a carreira como Administrador de Redes e atuou como membro da Equipe de Resposta a Incidentes de Segurança Computacional (CSIRT), construindo expertise fundamental em segurança cibernética.</p>
                     </div>
                 </div>
             </div>
@@ -1069,65 +1069,65 @@
     </section>
 
     <!-- Education Section -->
-    <section class="education" id="education">
+    <section class="education" id="formacao">
         <div class="container">
             <div class="section-header fade-in">
-                <h2>Education</h2>
+                <h2>Formação Acadêmica</h2>
                 <div class="section-divider"></div>
-                <p>Advanced degrees and specializations in computer science and military sciences</p>
+                <p>Graus avançados e especializações em ciência da computação e ciências militares</p>
             </div>
             <div class="education-grid">
                 <div class="education-card fade-in">
                     <span class="year">2020 – 2022</span>
-                    <h3>M.Sc. Computer Science</h3>
-                    <p class="institution">University of Brasília (UnB)</p>
-                    <p class="description">Dissertation: "BERT Self-Learning Approach with Limited Labels for Document Classification" – Research on NLP and machine learning for administrative document classification in the Brazilian Army.</p>
+                    <h3>Mestrado em Ciência da Computação</h3>
+                    <p class="institution">Universidade de Brasília (UnB)</p>
+                    <p class="description">Dissertação: "BERT Self-Learning Approach with Limited Labels for Document Classification" – Pesquisa sobre PLN e machine learning para classificação de documentos administrativos no Exército Brasileiro.</p>
                 </div>
                 <div class="education-card fade-in">
                     <span class="year">2018 – 2019</span>
-                    <h3>Postgraduate – Military Science & Operational Studies</h3>
-                    <p class="institution">School of Officer Improvement (EsAO)</p>
-                    <p class="description">Advanced studies in military science, operational planning, and strategic leadership.</p>
+                    <h3>Pós-Graduação – Ciência Militar & Estudos Operacionais</h3>
+                    <p class="institution">Escola de Aperfeiçoamento de Oficiais (EsAO)</p>
+                    <p class="description">Estudos avançados em ciência militar, planejamento operacional e liderança estratégica.</p>
                 </div>
                 <div class="education-card fade-in">
                     <span class="year">2010 – 2011</span>
-                    <h3>Postgraduate – Complementary Applications in Military Sciences</h3>
-                    <p class="institution">Army Management School (EGA)</p>
-                    <p class="description">Specialization in military sciences applications for organizational management.</p>
+                    <h3>Pós-Graduação – Aplicações Complementares em Ciências Militares</h3>
+                    <p class="institution">Escola de Gestão do Exército (EGA)</p>
+                    <p class="description">Especialização em aplicações de ciências militares para gestão organizacional.</p>
                 </div>
                 <div class="education-card fade-in">
                     <span class="year">2007 – 2009</span>
-                    <h3>Postgraduate – Cryptography & Network Security</h3>
-                    <p class="institution">Fluminense Federal University (UFF)</p>
-                    <p class="description">Advanced studies in cryptography, network security protocols, and secure communications.</p>
+                    <h3>Pós-Graduação – Criptografia & Segurança de Redes</h3>
+                    <p class="institution">Universidade Federal Fluminense (UFF)</p>
+                    <p class="description">Estudos avançados em criptografia, protocolos de segurança de rede e comunicações seguras.</p>
                 </div>
                 <div class="education-card fade-in">
                     <span class="year">2002 – 2005</span>
-                    <h3>B.Sc. Computational Information Systems</h3>
-                    <p class="institution">Federal University of Mato Grosso do Sul (UFMS)</p>
-                    <p class="description">Bachelor's degree in computer science with focus on information systems and software development.</p>
+                    <h3>Bacharelado em Sistemas de Informação Computacionais</h3>
+                    <p class="institution">Universidade Federal de Mato Grosso do Sul (UFMS)</p>
+                    <p class="description">Graduação em ciência da computação com foco em sistemas de informação e desenvolvimento de software.</p>
                 </div>
                 <div class="education-card fade-in">
                     <span class="year">2014</span>
-                    <h3>Cyber Defense Specialization</h3>
-                    <p class="institution">Brazilian Army Cyber Defense Center</p>
-                    <p class="description">Specialized training in cyber defense operations, incident response, and network security.</p>
+                    <h3>Especialização em Cibernetologia</h3>
+                    <p class="institution">Centro de Defesa Cibernética do Exército Brasileiro</p>
+                    <p class="description">Treinamento especializado em operações de defesa cibernética, resposta a incidentes e segurança de rede.</p>
                 </div>
             </div>
         </div>
     </section>
 
     <!-- Skills Section -->
-    <section class="skills" id="skills">
+    <section class="skills" id="habilidades">
         <div class="container">
             <div class="section-header fade-in">
-                <h2>Technical Skills</h2>
+                <h2>Habilidades Técnicas</h2>
                 <div class="section-divider"></div>
-                <p>Expertise across data engineering, software development, and cybersecurity</p>
+                <p>Expertise em engenharia de dados, desenvolvimento de software e segurança cibernética</p>
             </div>
             <div class="skills-grid">
                 <div class="skill-category fade-in">
-                    <h3><i class="fas fa-code"></i> Programming</h3>
+                    <h3><i class="fas fa-code"></i> Programação</h3>
                     <div class="skill-tags">
                         <span class="skill-tag">Python</span>
                         <span class="skill-tag">Java</span>
@@ -1137,23 +1137,23 @@
                     </div>
                 </div>
                 <div class="skill-category fade-in">
-                    <h3><i class="fas fa-database"></i> Data Engineering</h3>
+                    <h3><i class="fas fa-database"></i> Engenharia de Dados</h3>
                     <div class="skill-tags">
-                        <span class="skill-tag">Data Pipelines</span>
+                        <span class="skill-tag">Pipelines de Dados</span>
                         <span class="skill-tag">ETL/ELT</span>
-                        <span class="skill-tag">Data Modeling</span>
+                        <span class="skill-tag">Modelagem de Dados</span>
                         <span class="skill-tag">Pandas</span>
                         <span class="skill-tag">NumPy</span>
                     </div>
                 </div>
                 <div class="skill-category fade-in">
-                    <h3><i class="fas fa-brain"></i> Machine Learning & NLP</h3>
+                    <h3><i class="fas fa-brain"></i> Machine Learning & PLN</h3>
                     <div class="skill-tags">
                         <span class="skill-tag">BERT</span>
                         <span class="skill-tag">Transformers</span>
                         <span class="skill-tag">Scikit-learn</span>
                         <span class="skill-tag">Deep Learning</span>
-                        <span class="skill-tag">Sentiment Analysis</span>
+                        <span class="skill-tag">Análise de Sentimentos</span>
                     </div>
                 </div>
                 <div class="skill-category fade-in">
@@ -1167,23 +1167,23 @@
                     </div>
                 </div>
                 <div class="skill-category fade-in">
-                    <h3><i class="fas fa-shield-alt"></i> Cybersecurity</h3>
+                    <h3><i class="fas fa-shield-alt"></i> Segurança Cibernética</h3>
                     <div class="skill-tags">
-                        <span class="skill-tag">Information Security</span>
-                        <span class="skill-tag">Cryptography</span>
-                        <span class="skill-tag">Incident Response</span>
-                        <span class="skill-tag">Network Security</span>
+                        <span class="skill-tag">Segurança da Informação</span>
+                        <span class="skill-tag">Criptografia</span>
+                        <span class="skill-tag">Resposta a Incidentes</span>
+                        <span class="skill-tag">Segurança de Redes</span>
                         <span class="skill-tag">CSIRT</span>
                     </div>
                 </div>
                 <div class="skill-category fade-in">
-                    <h3><i class="fas fa-tools"></i> Tools & Platforms</h3>
+                    <h3><i class="fas fa-tools"></i> Ferramentas & Plataformas</h3>
                     <div class="skill-tags">
                         <span class="skill-tag">Jupyter Notebook</span>
                         <span class="skill-tag">Google Colab</span>
                         <span class="skill-tag">PostgreSQL</span>
                         <span class="skill-tag">MySQL</span>
-                        <span class="skill-tag">REST APIs</span>
+                        <span class="skill-tag">APIs REST</span>
                     </div>
                 </div>
             </div>
@@ -1191,12 +1191,12 @@
     </section>
 
     <!-- Certifications Section -->
-    <section class="certifications" id="certifications">
+    <section class="certifications" id="certificacoes">
         <div class="container">
             <div class="section-header fade-in">
-                <h2>Certifications</h2>
+                <h2>Certificações</h2>
                 <div class="section-divider"></div>
-                <p>Professional certifications and credentials</p>
+                <p>Certificações profissionais e credenciais</p>
             </div>
             <div class="cert-grid">
                 <!-- Oracle Certifications -->
@@ -1206,7 +1206,7 @@
                     </div>
                     <h3>Oracle Autonomous Database Cloud 2025 Certified Professional</h3>
                     <p class="issuer">Oracle</p>
-                    <p class="year">Oct 2025</p>
+                    <p class="year">Out 2025</p>
                 </div>
                 <div class="cert-card fade-in">
                     <div class="cert-icon">
@@ -1214,7 +1214,7 @@
                     </div>
                     <h3>Oracle Cloud Infrastructure 2025 Certified Foundations Associate</h3>
                     <p class="issuer">Oracle</p>
-                    <p class="year">Oct 2025</p>
+                    <p class="year">Out 2025</p>
                 </div>
                 <div class="cert-card fade-in">
                     <div class="cert-icon">
@@ -1222,7 +1222,7 @@
                     </div>
                     <h3>Oracle Cloud Infrastructure Data Science Professional</h3>
                     <p class="issuer">Oracle</p>
-                    <p class="year">Oct 2025</p>
+                    <p class="year">Out 2025</p>
                 </div>
 
                 <!-- AWS Certification -->
@@ -1232,7 +1232,7 @@
                     </div>
                     <h3>AWS Academy Graduate – Cloud Architecting</h3>
                     <p class="issuer">Amazon Web Services (AWS)</p>
-                    <p class="year">Dec 2024</p>
+                    <p class="year">Dez 2024</p>
                 </div>
 
                 <!-- Brazilian Army Certification -->
@@ -1240,9 +1240,9 @@
                     <div class="cert-icon">
                         <i class="fas fa-shield-alt"></i>
                     </div>
-                    <h3>Penetration Testing Sector Internship (Pentest)</h3>
-                    <p class="issuer">Brazilian Army (Exército Brasileiro)</p>
-                    <p class="year">Dec 2023</p>
+                    <h3>Estágio Setorial de Teste de Penetração (Pentest)</h3>
+                    <p class="issuer">Exército Brasileiro</p>
+                    <p class="year">Dez 2023</p>
                 </div>
 
                 <!-- Language Proficiency -->
@@ -1252,7 +1252,7 @@
                     </div>
                     <h3>EF English Level 16 – Upper Advanced (CEFR C2)</h3>
                     <p class="issuer">EF Education First</p>
-                    <p class="year">May 2018</p>
+                    <p class="year">Mai 2018</p>
                 </div>
                 <div class="cert-card fade-in">
                     <div class="cert-icon">
@@ -1268,8 +1268,8 @@
                     <div class="cert-icon">
                         <i class="fas fa-chart-bar"></i>
                     </div>
-                    <h3>Data Science & Statistics with Python</h3>
-                    <p class="issuer">Alura · 5 courses</p>
+                    <h3>Ciência de Dados & Estatística com Python</h3>
+                    <p class="issuer">Alura · 5 cursos</p>
                     <p class="year">2023</p>
                 </div>
 
@@ -1278,8 +1278,8 @@
                     <div class="cert-icon">
                         <i class="fas fa-robot"></i>
                     </div>
-                    <h3>Machine Learning & Deep Learning with PyTorch</h3>
-                    <p class="issuer">Alura · Advanced ML Track</p>
+                    <h3>Machine Learning & Deep Learning com PyTorch</h3>
+                    <p class="issuer">Alura · Trilha Avançada de ML</p>
                     <p class="year">2023</p>
                 </div>
 
@@ -1288,8 +1288,8 @@
                     <div class="cert-icon">
                         <i class="fas fa-file-alt"></i>
                     </div>
-                    <h3>Natural Language Processing & Multilabel Text Classification</h3>
-                    <p class="issuer">Alura · 3 courses</p>
+                    <h3>Processamento de Linguagem Natural & Classificação Multilabel de Textos</h3>
+                    <p class="issuer">Alura · 3 cursos</p>
                     <p class="year">2020</p>
                 </div>
 
@@ -1298,7 +1298,7 @@
                     <div class="cert-icon">
                         <i class="fas fa-server"></i>
                     </div>
-                    <h3>Kubernetes & Cloud-Native Applications</h3>
+                    <h3>Kubernetes & Aplicações Cloud-Native</h3>
                     <p class="issuer">Alura · DigitalOcean + Twelve-Factor App</p>
                     <p class="year">2022–2023</p>
                 </div>
@@ -1308,8 +1308,8 @@
                     <div class="cert-icon">
                         <i class="fas fa-database"></i>
                     </div>
-                    <h3>SQL with Oracle Database & ETL with Pentaho</h3>
-                    <p class="issuer">Alura · 4 courses</p>
+                    <h3>SQL com Oracle Database & ETL com Pentaho</h3>
+                    <p class="issuer">Alura · 4 cursos</p>
                     <p class="year">2022–2023</p>
                 </div>
 
@@ -1319,7 +1319,7 @@
                         <i class="fas fa-chart-pie"></i>
                     </div>
                     <h3>Business Intelligence – Power BI & MicroStrategy</h3>
-                    <p class="issuer">Alura · 9 courses</p>
+                    <p class="issuer">Alura · 9 cursos</p>
                     <p class="year">2022–2023</p>
                 </div>
 
@@ -1328,8 +1328,8 @@
                     <div class="cert-icon">
                         <i class="fas fa-code"></i>
                     </div>
-                    <h3>Web Development – React, Spring Boot & Java Security</h3>
-                    <p class="issuer">Alura · 4 courses</p>
+                    <h3>Desenvolvimento Web – React, Spring Boot & Java Security</h3>
+                    <p class="issuer">Alura · 4 cursos</p>
                     <p class="year">2018–2023</p>
                 </div>
 
@@ -1338,8 +1338,8 @@
                     <div class="cert-icon">
                         <i class="fas fa-tasks"></i>
                     </div>
-                    <h3>Scrum & UX Design Strategy</h3>
-                    <p class="issuer">Alura · 4 courses</p>
+                    <h3>Scrum & Estratégia de UX Design</h3>
+                    <p class="issuer">Alura · 4 cursos</p>
                     <p class="year">2018</p>
                 </div>
 
@@ -1348,75 +1348,75 @@
                     <div class="cert-icon">
                         <i class="fas fa-fire"></i>
                     </div>
-                    <h3>Apache Spark with Python</h3>
+                    <h3>Apache Spark com Python</h3>
                     <p class="issuer">Alura</p>
-                    <p class="year">May 2023</p>
+                    <p class="year">Mai 2023</p>
                 </div>
             </div>
         </div>
     </section>
 
     <!-- Publications Section -->
-    <section class="publications" id="publications">
+    <section class="publications" id="publicacoes">
         <div class="container">
             <div class="section-header fade-in">
-                <h2>Publications & Articles</h2>
+                <h2>Publicações & Artigos</h2>
                 <div class="section-divider"></div>
-                <p>Academic research and technical articles</p>
+                <p>Pesquisa acadêmica e artigos técnicos</p>
             </div>
             <div class="pub-list">
                 <div class="pub-item fade-in">
-                    <span class="pub-type">Article</span>
+                    <span class="pub-type">Artigo</span>
                     <h3>5 Game-Changing Tips for Debugging Jupyter Notebooks</h3>
                     <p class="pub-authors">Carlos Eduardo de Lima Joaquim</p>
-                    <p class="pub-venue">LinkedIn Article, October 2025</p>
+                    <p class="pub-venue">LinkedIn Article, Outubro 2025</p>
                     <a href="https://www.linkedin.com/pulse/5-game-changing-tips-debugging-jupyter-notebooks-de-lima-joaquim-agcjf" target="_blank" rel="noopener noreferrer" class="pub-link">
-                        Read Article <i class="fas fa-external-link-alt"></i>
+                        Ler Artigo <i class="fas fa-external-link-alt"></i>
                     </a>
                 </div>
                 <div class="pub-item fade-in">
-                    <span class="pub-type">Conference Paper</span>
+                    <span class="pub-type">Artigo de Conferência</span>
                     <h3>BERT Self-Learning Approach with Limited Labels for Document Classification</h3>
                     <p class="pub-authors">C. E. L. Joaquim, T. P. Faleinos</p>
                     <p class="pub-venue">Learning and Intelligent Optimization (LION 16), 2023</p>
                     <a href="https://scholar.google.com.br/citations?user=bkzHrXcAAAAJ" target="_blank" rel="noopener noreferrer" class="pub-link">
-                        View on Google Scholar <i class="fas fa-external-link-alt"></i>
+                        Ver no Google Scholar <i class="fas fa-external-link-alt"></i>
                     </a>
                 </div>
                 <div class="pub-item fade-in">
-                    <span class="pub-type">Dissertation</span>
+                    <span class="pub-type">Dissertação</span>
                     <h3>BERT Self-Learning Approach with Limited Labels for Document Classification of a Brazilian Army's Administrative Documentary Set</h3>
                     <p class="pub-authors">Carlos Eduardo de Lima Joaquim</p>
-                    <p class="pub-venue">University of Brasília (UnB), 2022</p>
+                    <p class="pub-venue">Universidade de Brasília (UnB), 2022</p>
                     <a href="https://scholar.google.com.br/citations?user=bkzHrXcAAAAJ" target="_blank" rel="noopener noreferrer" class="pub-link">
-                        View on Google Scholar <i class="fas fa-external-link-alt"></i>
+                        Ver no Google Scholar <i class="fas fa-external-link-alt"></i>
                     </a>
                 </div>
                 <div class="pub-item fade-in">
-                    <span class="pub-type">Journal Article</span>
+                    <span class="pub-type">Artigo de Revista</span>
                     <h3>Análise de sentimentos da população brasileira durante a pandemia de COVID-19 como ferramenta de exploração da expressão psicossocial no espaço cibernético</h3>
                     <p class="pub-authors">C. E. de Lima Joaquim, C. H. M. Barbosa, E. Ishikawa</p>
                     <p class="pub-venue">Revista Ibérica de Sistemas e Tecnologias de Informação, 2021</p>
                     <a href="https://scholar.google.com.br/citations?user=bkzHrXcAAAAJ" target="_blank" rel="noopener noreferrer" class="pub-link">
-                        View on Google Scholar <i class="fas fa-external-link-alt"></i>
+                        Ver no Google Scholar <i class="fas fa-external-link-alt"></i>
                     </a>
                 </div>
                 <div class="pub-item fade-in">
-                    <span class="pub-type">Journal Article</span>
+                    <span class="pub-type">Artigo de Revista</span>
                     <h3>Educação de adultos no sistema de ensino regular à distância do Exército Brasileiro</h3>
                     <p class="pub-authors">Carlos Eduardo de Lima Joaquim</p>
                     <p class="pub-venue">2018</p>
                     <a href="https://scholar.google.com.br/citations?user=bkzHrXcAAAAJ" target="_blank" rel="noopener noreferrer" class="pub-link">
-                        View on Google Scholar <i class="fas fa-external-link-alt"></i>
+                        Ver no Google Scholar <i class="fas fa-external-link-alt"></i>
                     </a>
                 </div>
                 <div class="pub-item fade-in">
-                    <span class="pub-type">Journal Article</span>
+                    <span class="pub-type">Artigo de Revista</span>
                     <h3>Sistema integrado de avaliação escolar: Aprimoramento e implantação dos módulos administrativo, afetivo e cognitivo</h3>
                     <p class="pub-authors">A. Pinheiro, A. S. de Aguiar, C. R. R. Machado, C. E. de Lima Joaquim, et al.</p>
                     <p class="pub-venue">RICAM Revista Interdisciplinar de Ciências Aplicadas à Atividade Militar, 2011</p>
                     <a href="https://scholar.google.com.br/citations?user=bkzHrXcAAAAJ" target="_blank" rel="noopener noreferrer" class="pub-link">
-                        View on Google Scholar <i class="fas fa-external-link-alt"></i>
+                        Ver no Google Scholar <i class="fas fa-external-link-alt"></i>
                     </a>
                 </div>
             </div>
@@ -1424,12 +1424,12 @@
     </section>
 
     <!-- Contact Section -->
-    <section class="contact" id="contact">
+    <section class="contact" id="contato">
         <div class="container">
             <div class="section-header fade-in">
-                <h2>Get in Touch</h2>
+                <h2>Entre em Contato</h2>
                 <div class="section-divider"></div>
-                <p>Feel free to connect with me through any of the channels below</p>
+                <p>Sinta-se à vontade para conectar-se através de qualquer um dos canais abaixo</p>
             </div>
             <div class="contact-links">
                 <a href="https://www.linkedin.com/in/eduardodelima/" target="_blank" rel="noopener noreferrer" class="contact-item fade-in">
@@ -1450,7 +1450,7 @@
                     <i class="fas fa-graduation-cap"></i>
                     <div class="contact-info">
                         <h3>Google Scholar</h3>
-                        <span>Academic Publications & Research</span>
+                        <span>Publicações Acadêmicas & Pesquisa</span>
                     </div>
                 </a>
             </div>
@@ -1471,7 +1471,7 @@
                     <i class="fas fa-graduation-cap"></i>
                 </a>
             </div>
-            <p>&copy; 2025 Carlos Eduardo de Lima Joaquim. All rights reserved.</p>
+            <p>&copy; 2025 Carlos Eduardo de Lima Joaquim. Todos os direitos reservados.</p>
         </div>
     </footer>
 
@@ -1509,7 +1509,7 @@
 
         // Fade-in animation on scroll
         const fadeElements = document.querySelectorAll('.fade-in');
-        
+
         const observerOptions = {
             threshold: 0.1,
             rootMargin: '0px 0px -50px 0px'


### PR DESCRIPTION
## Changes

### Certifications Section
- Expanded from 3 to **16 grouped certification cards** covering **45+ credentials**:
  - **Oracle** (3): Autonomous Database Cloud, OCI Foundations, OCI Data Science
  - **AWS** (1): Cloud Architecting Graduate
  - **Brazilian Army** (1): Penetration Testing (Pentest)
  - **Language Proficiency** (2): EF C2 English, Duolingo Expert
  - **Alura** (10 topic-grouped cards): Data Science, ML/DL, NLP, Kubernetes/DevOps, Oracle/ETL, BI, Web Dev, Agile/UX, Apache Spark

### Portuguese Language Support
- Created **index-pt.html** with full Brazilian Portuguese translation
- All navigation labels, sections, descriptions, and UI text translated
- Certification titles kept in English as professional credentials

### Language Toggle
- Added **🇺🇸 EN | 🇧🇷 PT** switcher in the top navigation bar
- Active language is highlighted; links between both pages
- Responsive design for mobile